### PR TITLE
Untar openfst tar before configure

### DIFF
--- a/install_openfst.sh
+++ b/install_openfst.sh
@@ -7,6 +7,7 @@ OPENFST_VERSION=1.6.1
 sudo apt-get install -y wget make gcc g++ checkinstall python-dev libz-dev
 
 wget http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-${OPENFST_VERSION}.tar.gz
+tar -xvf openfst-${OPENFST_VERSION}.tar.gz openfst-${OPENFST_VERSION}
 cd openfst-${OPENFST_VERSION}
 ./configure --enable-static=yes --enable-shared=no --with-pic=yes --enable-far --enable-python
 make -j${NUM_CPUS}


### PR DESCRIPTION
# Changes
Adds a line to the install opensft script in order to untar the file that you download with wget.

# Environment
Description:	Ubuntu 18.04.1 LTS
Release:	18.04
Codename:	bionic

# Commitment

- [x] I tested the script to see if it works after the change