### PR TITLE
Update install_openfst.sh

### DIFF
--- a/install_openfst.sh
+++ b/install_openfst.sh
@@ -2,13 +2,14 @@
 
 NUM_CPUS=`cat /proc/cpuinfo | grep proc | wc -l`
 OPENFST_VERSION=1.6.1
-
+# max number of jobs is ncpus - 1
+NUM_JOBS=$(($NUM_CPUS - 1))
 
 sudo apt-get install -y wget make gcc g++ checkinstall python-dev libz-dev
 
 wget http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-${OPENFST_VERSION}.tar.gz
 tar -xvf openfst-${OPENFST_VERSION}.tar.gz openfst-${OPENFST_VERSION}
 cd openfst-${OPENFST_VERSION}
-./configure --enable-static=yes --enable-shared=no --with-pic=yes --enable-far --enable-python
-make -j${NUM_CPUS}
+./configure --enable-static=yes --enable-shared=no --with-pic=yes --enable-far
+make -j${NUM_JOBS}
 sudo make install


### PR DESCRIPTION
Changes:

 * Made number of jobs NCPUS - 1 since the system cannot operate when make makes full use of the processing power
 * `--enable-python` causes bugs in configuration. A better workaround is to add a `pip3 install openfst` in the end of the script. 